### PR TITLE
feature: recompile sodium with new ndk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    ndkVersion '21.3.6528147'
+    ndkVersion '21.4.7075529'
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"

--- a/libsodium-1.0.18-stable.tar.gz.minisig
+++ b/libsodium-1.0.18-stable.tar.gz.minisig
@@ -1,4 +1,4 @@
 untrusted comment: signature from minisign secret key
-RWQf6LRCGA9i58gQqf9wSHymGD7tdFz4guwa9XgfU1ZWribcrPfy0pMu8XFIY1ENlPFGYULdBPpOwHGFvogBrjPDUXOVUXa+0wA=
-trusted comment: timestamp:1609461441	file:libsodium-stable.tar.gz
-y14K5iXFkbTYDSI9Mj6mChzFakBj0tIHLr9IWq4mN3BQ5KeJNgQ0WzeizsNll3AS/RrlVfXhPTB0v85LWiPaDQ==
+RWQf6LRCGA9i5033a+CEkW320ZEJrnT7XSdgTGN2LYQaGlgIHu2+NKz2BiMhzIg0kSyflz2OsrQuf9Gm4fO/+UUDeTTQjoEJeQA=
+trusted comment: timestamp:1613522237	file:libsodium-stable.tar.gz
+Y7JeJwgCbzwYexeoIvdCXXwQGemIIv53lNq/aBEbKvNoo0a+ALprRktSosfVcKltnz8HMQuLH0EovspJ/yIPBg==


### PR DESCRIPTION
This updates react-native-sodium binary recompiled with the new Android ndk that is supported by current Github Actions ubuntu machine.